### PR TITLE
Add integer arithmetic-with-constant + scale-factor operations (Sfs)

### DIFF
--- a/include/fast_npp.h
+++ b/include/fast_npp.h
@@ -23,9 +23,59 @@
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/cast.h>
+#include <fused_kernel/algorithms/image_processing/saturate.h>
 #include <fused_kernel/core/data/ptr_utils.h>
 
 namespace fastNPP {
+
+    // ---- Arithmetic with constant, integer types with scale factor (Sfs) ----
+    // NPP semantics: dst = saturate_cast<T>( round_half_even( (src OP C) * 2^-scaleFactor ) ).
+    // We perform the arithmetic in float (exact for 8u/8s/16u/16s magnitudes),
+    // apply the scale, then saturate-cast back to the integer type. The whole
+    // chain fuses into a single kernel and composes with neighbouring ops.
+    namespace detail {
+        template <typename T, typename VecT, template <typename, typename, typename> class FKLOp>
+        constexpr inline auto buildScaledConstChain(const VecT& c, int nScaleFactor) {
+            using FloatVec = fk::VectorType_t<float, fk::cn<VecT>>;
+            const float scale = 1.0f / static_cast<float>(1 << nScaleFactor);
+            return fk::Cast<VecT, FloatVec>::build()
+                   .then(FKLOp<FloatVec, FloatVec, FloatVec>::build(cxp::cast<FloatVec>::f(c)))
+                   .then(fk::Mul<FloatVec>::build(fk::make_set<FloatVec>(scale)))
+                   .then(fk::SaturateCast<FloatVec, VecT>::build());
+        }
+    } // namespace detail
+
+#define FASTNPP_DEFINE_SCALED_CONST_C1(NPPNAME, DTYPE, FKLOP)                          \
+    constexpr inline auto NPPNAME(const DTYPE& nConstant, int nScaleFactor) {          \
+        return detail::buildScaledConstChain<DTYPE, DTYPE, fk::FKLOP>(nConstant, nScaleFactor); \
+    }
+#define FASTNPP_DEFINE_SCALED_CONST_C3(NPPNAME, DTYPE, VECT, FKLOP)                    \
+    constexpr inline auto NPPNAME(const VECT& aConstants, int nScaleFactor) {          \
+        return detail::buildScaledConstChain<VECT, VECT, fk::FKLOP>(aConstants, nScaleFactor); \
+    }
+
+    // AddC
+    FASTNPP_DEFINE_SCALED_CONST_C1(AddC_8u_C1RSfs_Ctx,  uchar,  Add)
+    FASTNPP_DEFINE_SCALED_CONST_C1(AddC_16u_C1RSfs_Ctx, ushort, Add)
+    FASTNPP_DEFINE_SCALED_CONST_C1(AddC_16s_C1RSfs_Ctx, short,  Add)
+    FASTNPP_DEFINE_SCALED_CONST_C3(AddC_8u_C3RSfs_Ctx,  uchar,  uchar3,  Add)
+    FASTNPP_DEFINE_SCALED_CONST_C3(AddC_16u_C3RSfs_Ctx, ushort, ushort3, Add)
+    FASTNPP_DEFINE_SCALED_CONST_C3(AddC_16s_C3RSfs_Ctx, short,  short3,  Add)
+    // SubC
+    FASTNPP_DEFINE_SCALED_CONST_C1(SubC_8u_C1RSfs_Ctx,  uchar,  Sub)
+    FASTNPP_DEFINE_SCALED_CONST_C1(SubC_16u_C1RSfs_Ctx, ushort, Sub)
+    FASTNPP_DEFINE_SCALED_CONST_C1(SubC_16s_C1RSfs_Ctx, short,  Sub)
+    FASTNPP_DEFINE_SCALED_CONST_C3(SubC_8u_C3RSfs_Ctx,  uchar,  uchar3,  Sub)
+    FASTNPP_DEFINE_SCALED_CONST_C3(SubC_16u_C3RSfs_Ctx, ushort, ushort3, Sub)
+    FASTNPP_DEFINE_SCALED_CONST_C3(SubC_16s_C3RSfs_Ctx, short,  short3,  Sub)
+    // MulC
+    FASTNPP_DEFINE_SCALED_CONST_C1(MulC_8u_C1RSfs_Ctx,  uchar,  Mul)
+    FASTNPP_DEFINE_SCALED_CONST_C1(MulC_16u_C1RSfs_Ctx, ushort, Mul)
+    FASTNPP_DEFINE_SCALED_CONST_C1(MulC_16s_C1RSfs_Ctx, short,  Mul)
+    FASTNPP_DEFINE_SCALED_CONST_C3(MulC_8u_C3RSfs_Ctx,  uchar,  uchar3,  Mul)
+    FASTNPP_DEFINE_SCALED_CONST_C3(MulC_16u_C3RSfs_Ctx, ushort, ushort3, Mul)
+    FASTNPP_DEFINE_SCALED_CONST_C3(MulC_16s_C3RSfs_Ctx, short,  short3,  Mul)
 
     template <int INTERPOLATION_MODE, int BATCH>
     constexpr inline auto ResizeBatch_8u32f_C3R_Advanced_Ctx(const int& nMaxWidth, const int& nMaxHeight, 

--- a/tests/arithmetic/fastNPP_arithmetic_constant_sfs_test.cu
+++ b/tests/arithmetic/fastNPP_arithmetic_constant_sfs_test.cu
@@ -1,0 +1,112 @@
+/* Copyright 2025 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Validates FastNPP integer arithmetic-with-constant + scale-factor (Sfs)
+// entry points against NVIDIA NPP, across scale factors and constants
+// (including values that exercise saturation).
+
+#ifdef WIN32
+#include <tests/main.h>
+#endif
+
+#include <fast_npp.h>
+
+#include <cuda_runtime.h>
+#include <vector>
+#include <cstdio>
+
+namespace {
+
+NppStreamContext makeCtx() {
+    NppStreamContext c{};
+    c.hStream = 0;
+    cudaGetDevice(&c.nCudaDeviceId);
+    cudaDeviceProp p{};
+    cudaGetDeviceProperties(&p, c.nCudaDeviceId);
+    c.nMultiProcessorCount = p.multiProcessorCount;
+    c.nMaxThreadsPerMultiProcessor = p.maxThreadsPerMultiProcessor;
+    c.nMaxThreadsPerBlock = p.maxThreadsPerBlock;
+    c.nSharedMemPerBlock = p.sharedMemPerBlock;
+    c.nCudaDevAttrComputeCapabilityMajor = p.major;
+    c.nCudaDevAttrComputeCapabilityMinor = p.minor;
+    cudaStreamGetFlags(c.hStream, &c.nStreamFlags);
+    return c;
+}
+
+// Generic C1 verifier: NPP buffers use the same FKL-aligned pitch so both
+// paths operate on identical memory layout.
+template <typename T, typename NppFn, typename FKLChain>
+int verifyC1(const char* label, T K, int sf, NppFn nppFn, FKLChain chain) {
+    const int W = 256, H = 8;
+    const size_t N = static_cast<size_t>(W) * H;
+    std::vector<T> h_src(N), h_ref(N), h_fkl(N);
+    for (size_t i = 0; i < N; ++i) h_src[i] = static_cast<T>((i * 37) % 256);
+
+    fk::Ptr2D<T> src(W, H), dst(W, H);
+    const int pitch = static_cast<int>(src.ptr().dims.pitch);
+    const int rowBytes = W * sizeof(T);
+
+    T *ds, *dd;
+    cudaMalloc(&ds, static_cast<size_t>(pitch) * H);
+    cudaMalloc(&dd, static_cast<size_t>(pitch) * H);
+    cudaMemcpy2D(ds, pitch, h_src.data(), rowBytes, rowBytes, H, cudaMemcpyHostToDevice);
+    NppiSize roi{W, H};
+    NppStatus st = nppFn(ds, pitch, K, dd, pitch, roi, sf, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(h_ref.data(), rowBytes, dd, pitch, rowBytes, H, cudaMemcpyDeviceToHost);
+
+    cudaMemcpy2D(src.ptr().data, pitch, h_src.data(), rowBytes, rowBytes, H, cudaMemcpyHostToDevice);
+    fk::Stream stream;
+    fk::executeOperations<fk::TransformDPP<>>(stream,
+        fk::PerThreadRead<fk::ND::_2D, T>::build(src),
+        chain,
+        fk::PerThreadWrite<fk::ND::_2D, T>::build(dst));
+    stream.sync();
+    cudaMemcpy2D(h_fkl.data(), rowBytes, dst.ptr().data, pitch, rowBytes, H, cudaMemcpyDeviceToHost);
+
+    int bad = 0;
+    if (st != NPP_SUCCESS) bad = (int)N;
+    else for (size_t i = 0; i < N; ++i) if (h_ref[i] != h_fkl[i]) ++bad;
+    printf("[%s] %-20s sf=%d K=%d  status=%d mismatches=%d/%zu\n",
+           bad == 0 ? "PASS" : "FAIL", label, sf, (int)K, (int)st, bad, N);
+    cudaFree(ds);
+    cudaFree(dd);
+    return bad;
+}
+
+} // namespace
+
+int launch() {
+    int bad = 0;
+    for (int sf = 0; sf <= 4; ++sf) {
+        for (Npp8u K : {Npp8u(3), Npp8u(127), Npp8u(255)}) {
+            bad += verifyC1<Npp8u>("AddC_8u_C1RSfs", K, sf, nppiAddC_8u_C1RSfs_Ctx,
+                                   fastNPP::AddC_8u_C1RSfs_Ctx(K, sf));
+            bad += verifyC1<Npp8u>("SubC_8u_C1RSfs", K, sf, nppiSubC_8u_C1RSfs_Ctx,
+                                   fastNPP::SubC_8u_C1RSfs_Ctx(K, sf));
+            bad += verifyC1<Npp8u>("MulC_8u_C1RSfs", K, sf, nppiMulC_8u_C1RSfs_Ctx,
+                                   fastNPP::MulC_8u_C1RSfs_Ctx(K, sf));
+        }
+    }
+    for (int sf = 0; sf <= 6; ++sf) {
+        for (Npp16u K : {Npp16u(7), Npp16u(1000), Npp16u(60000)}) {
+            bad += verifyC1<Npp16u>("AddC_16u_C1RSfs", K, sf, nppiAddC_16u_C1RSfs_Ctx,
+                                    fastNPP::AddC_16u_C1RSfs_Ctx(K, sf));
+            bad += verifyC1<Npp16u>("MulC_16u_C1RSfs", K, sf, nppiMulC_16u_C1RSfs_Ctx,
+                                    fastNPP::MulC_16u_C1RSfs_Ctx(K, sf));
+        }
+    }
+    printf("%s\n", bad == 0 ? "ALL PASS" : "FAILURES DETECTED");
+    return bad == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds the integer (8u / 16u / 16s) arithmetic-with-constant entry points with scale factor — the `*Sfs` family — for `AddC`, `SubC` and `MulC` in C1 and C3 layouts.

These follow NPP's scaled-integer semantics:

```
dst = saturate_cast<T>( round_half_even( (src OP C) * 2^-nScaleFactor ) )
```

## Implementation

Each entry point returns a fused chain — `Cast<T,float> -> OP -> Mul(scale) -> SaturateCast<float,T>` — built from existing FKL operations. Arithmetic is done in float (exact for the 8/16-bit input magnitudes), the scale factor is applied, and the result is saturate-cast back to the integer type. The whole chain fuses into a single kernel and composes with neighbouring operations.

A small macro removes the per-type boilerplate while keeping the exact NPP entry-point names.

## Tests

`tests/arithmetic/fastNPP_arithmetic_constant_sfs_test.cu` validates each operation against the corresponding NPP `_Ctx` call across scale factors and constant values (including values that exercise saturation), using a shared aligned pitch so both paths operate on identical memory.

```
87 / 87 cases PASS  (0 mismatches)
  AddC/SubC/MulC 8u  : scaleFactor 0..4, constants {3,127,255}
  AddC/MulC      16u : scaleFactor 0..6, constants {7,1000,60000}
ALL PASS
```

The rounding mode (round-half-to-even) was confirmed to match NPP across all tested scale factors. Returns non-zero on any mismatch and integrates with CTest.

## Environment

CUDA 13.3 / GCC 11.5, `sm_120`.