### PR TITLE
Add bitwise and element-wise math operations

### DIFF
--- a/include/fast_npp.h
+++ b/include/fast_npp.h
@@ -23,9 +23,70 @@
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/bitwise.h>
+#include <fused_kernel/algorithms/basic_ops/math.h>
 #include <fused_kernel/core/data/ptr_utils.h>
 
 namespace fastNPP {
+
+    // ===== Bitwise operations =====
+    // AndC / OrC / XorC with a constant, and Not (no constant). Integer types,
+    // C1 / C3 / C4. Each maps the exact NPP name onto an FKL bitwise functor.
+#define FASTNPP_DEFINE_BITWISE_C(NPPNAME, T, FKLOP)                        \
+    constexpr inline auto NPPNAME(const T& nConstant) {                    \
+        return fk::FKLOP<T>::build(nConstant);                             \
+    }
+#define FASTNPP_DEFINE_BITWISE_CVEC(NPPNAME, VECT, FKLOP)                  \
+    constexpr inline auto NPPNAME(const VECT& aConstants) {                \
+        return fk::FKLOP<VECT>::build(aConstants);                         \
+    }
+#define FASTNPP_DEFINE_NOT(NPPNAME, T)                                     \
+    constexpr inline auto NPPNAME() { return fk::BwNot<T>::build(); }
+
+    // AndC
+    FASTNPP_DEFINE_BITWISE_C(AndC_8u_C1R_Ctx,   uchar,  BwAnd)
+    FASTNPP_DEFINE_BITWISE_C(AndC_16u_C1R_Ctx,  ushort, BwAnd)
+    FASTNPP_DEFINE_BITWISE_C(AndC_32s_C1R_Ctx,  int,    BwAnd)
+    FASTNPP_DEFINE_BITWISE_CVEC(AndC_8u_C3R_Ctx,  uchar3,  BwAnd)
+    FASTNPP_DEFINE_BITWISE_CVEC(AndC_8u_C4R_Ctx,  uchar4,  BwAnd)
+    FASTNPP_DEFINE_BITWISE_CVEC(AndC_16u_C3R_Ctx, ushort3, BwAnd)
+    FASTNPP_DEFINE_BITWISE_CVEC(AndC_16u_C4R_Ctx, ushort4, BwAnd)
+    // OrC
+    FASTNPP_DEFINE_BITWISE_C(OrC_8u_C1R_Ctx,   uchar,  BwOr)
+    FASTNPP_DEFINE_BITWISE_C(OrC_16u_C1R_Ctx,  ushort, BwOr)
+    FASTNPP_DEFINE_BITWISE_C(OrC_32s_C1R_Ctx,  int,    BwOr)
+    FASTNPP_DEFINE_BITWISE_CVEC(OrC_8u_C3R_Ctx,  uchar3,  BwOr)
+    FASTNPP_DEFINE_BITWISE_CVEC(OrC_8u_C4R_Ctx,  uchar4,  BwOr)
+    FASTNPP_DEFINE_BITWISE_CVEC(OrC_16u_C3R_Ctx, ushort3, BwOr)
+    FASTNPP_DEFINE_BITWISE_CVEC(OrC_16u_C4R_Ctx, ushort4, BwOr)
+    // XorC
+    FASTNPP_DEFINE_BITWISE_C(XorC_8u_C1R_Ctx,   uchar,  BwXor)
+    FASTNPP_DEFINE_BITWISE_C(XorC_16u_C1R_Ctx,  ushort, BwXor)
+    FASTNPP_DEFINE_BITWISE_C(XorC_32s_C1R_Ctx,  int,    BwXor)
+    FASTNPP_DEFINE_BITWISE_CVEC(XorC_8u_C3R_Ctx,  uchar3,  BwXor)
+    FASTNPP_DEFINE_BITWISE_CVEC(XorC_8u_C4R_Ctx,  uchar4,  BwXor)
+    FASTNPP_DEFINE_BITWISE_CVEC(XorC_16u_C3R_Ctx, ushort3, BwXor)
+    FASTNPP_DEFINE_BITWISE_CVEC(XorC_16u_C4R_Ctx, ushort4, BwXor)
+    // Not
+    FASTNPP_DEFINE_NOT(Not_8u_C1R_Ctx, uchar)
+    FASTNPP_DEFINE_NOT(Not_8u_C3R_Ctx, uchar3)
+    FASTNPP_DEFINE_NOT(Not_8u_C4R_Ctx, uchar4)
+
+    // ===== Element-wise math (32f) =====
+    // Abs / Sqr / Sqrt / Ln / Exp, C1 / C3.
+#define FASTNPP_DEFINE_MATH(NPPNAME, T, FKLOP)                             \
+    constexpr inline auto NPPNAME() { return fk::FKLOP<T>::build(); }
+
+    FASTNPP_DEFINE_MATH(Abs_32f_C1R_Ctx,  float,  Abs)
+    FASTNPP_DEFINE_MATH(Abs_32f_C3R_Ctx,  float3, Abs)
+    FASTNPP_DEFINE_MATH(Sqr_32f_C1R_Ctx,  float,  Sqr)
+    FASTNPP_DEFINE_MATH(Sqr_32f_C3R_Ctx,  float3, Sqr)
+    FASTNPP_DEFINE_MATH(Sqrt_32f_C1R_Ctx, float,  Sqrt)
+    FASTNPP_DEFINE_MATH(Sqrt_32f_C3R_Ctx, float3, Sqrt)
+    FASTNPP_DEFINE_MATH(Ln_32f_C1R_Ctx,   float,  Ln)
+    FASTNPP_DEFINE_MATH(Ln_32f_C3R_Ctx,   float3, Ln)
+    FASTNPP_DEFINE_MATH(Exp_32f_C1R_Ctx,  float,  Exp)
+    FASTNPP_DEFINE_MATH(Exp_32f_C3R_Ctx,  float3, Exp)
 
     template <int INTERPOLATION_MODE, int BATCH>
     constexpr inline auto ResizeBatch_8u32f_C3R_Advanced_Ctx(const int& nMaxWidth, const int& nMaxHeight, 

--- a/tests/arithmetic/fastNPP_bitwise_math_test.cu
+++ b/tests/arithmetic/fastNPP_bitwise_math_test.cu
@@ -1,0 +1,158 @@
+/* Copyright 2025 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Validates FastNPP bitwise (AndC/OrC/XorC/Not) and element-wise math
+// (Abs/Sqr/Sqrt/Ln/Exp) entry points against NVIDIA NPP.
+
+#ifdef WIN32
+#include <tests/main.h>
+#endif
+
+#include <fast_npp.h>
+#include <cuda_runtime.h>
+#include <vector>
+#include <cstdio>
+#include <cmath>
+
+namespace {
+
+NppStreamContext makeCtx() {
+    NppStreamContext c{};
+    c.hStream = 0;
+    cudaGetDevice(&c.nCudaDeviceId);
+    cudaDeviceProp p{};
+    cudaGetDeviceProperties(&p, c.nCudaDeviceId);
+    c.nMultiProcessorCount = p.multiProcessorCount;
+    c.nMaxThreadsPerMultiProcessor = p.maxThreadsPerMultiProcessor;
+    c.nMaxThreadsPerBlock = p.maxThreadsPerBlock;
+    c.nSharedMemPerBlock = p.sharedMemPerBlock;
+    c.nCudaDevAttrComputeCapabilityMajor = p.major;
+    c.nCudaDevAttrComputeCapabilityMinor = p.minor;
+    cudaStreamGetFlags(c.hStream, &c.nStreamFlags);
+    return c;
+}
+
+// Bitwise C1 with constant.
+template <typename T, typename NppFn, typename FKLChain>
+int bwConstC1(const char* label, T K, NppFn nppFn, FKLChain chain) {
+    const int W = 256, H = 8;
+    const size_t N = static_cast<size_t>(W) * H;
+    std::vector<T> h(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) h[i] = static_cast<T>((i * 53) % 256);
+    fk::Ptr2D<T> s(W, H), d(W, H);
+    const int pitch = (int)s.ptr().dims.pitch, rb = W * sizeof(T);
+    T *ds, *dd;
+    cudaMalloc(&ds, (size_t)pitch * H);
+    cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(ds, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppFn(ds, pitch, K, dd, pitch, {W, H}, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s.ptr().data, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st,
+        fk::PerThreadRead<fk::ND::_2D, T>::build(s), chain,
+        fk::PerThreadWrite<fk::ND::_2D, T>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0;
+    for (size_t i = 0; i < N; ++i) if (ref[i] != fkl[i]) ++bad;
+    printf("[%s] %-14s K=%3d mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", label, (int)K, bad, N);
+    cudaFree(ds); cudaFree(dd);
+    return bad;
+}
+
+// Math C1 (32f), tolerance-based.
+template <typename NppFn, typename FKLChain>
+int mathC1(const char* label, NppFn nppFn, FKLChain chain, float lo, float hi, float tol) {
+    const int W = 512, H = 8;
+    const size_t N = static_cast<size_t>(W) * H;
+    std::vector<float> h(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) h[i] = lo + (hi - lo) * ((float)(i % 997) / 997.0f);
+    fk::Ptr2D<float> s(W, H), d(W, H);
+    const int pitch = (int)s.ptr().dims.pitch, rb = W * sizeof(float);
+    Npp32f *ds, *dd;
+    cudaMalloc(&ds, (size_t)pitch * H);
+    cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(ds, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppFn(ds, pitch, dd, pitch, {W, H}, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s.ptr().data, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st,
+        fk::PerThreadRead<fk::ND::_2D, float>::build(s), chain,
+        fk::PerThreadWrite<fk::ND::_2D, float>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0; double maxd = 0;
+    for (size_t i = 0; i < N; ++i) {
+        double e = std::fabs((double)ref[i] - (double)fkl[i]);
+        if (e > maxd) maxd = e;
+        if (e > tol) ++bad;
+    }
+    printf("[%s] %-14s max|d|=%.2e mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", label, maxd, bad, N);
+    cudaFree(ds); cudaFree(dd);
+    return bad;
+}
+
+int notC1() {
+    const int W = 256, H = 8;
+    const size_t N = static_cast<size_t>(W) * H;
+    std::vector<Npp8u> h(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) h[i] = (Npp8u)((i * 53) % 256);
+    fk::Ptr2D<uchar> s(W, H), d(W, H);
+    const int pitch = (int)s.ptr().dims.pitch, rb = W;
+    Npp8u *ds, *dd;
+    cudaMalloc(&ds, (size_t)pitch * H);
+    cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(ds, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppiNot_8u_C1R_Ctx(ds, pitch, dd, pitch, {W, H}, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s.ptr().data, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st,
+        fk::PerThreadRead<fk::ND::_2D, uchar>::build(s),
+        fastNPP::Not_8u_C1R_Ctx(),
+        fk::PerThreadWrite<fk::ND::_2D, uchar>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0;
+    for (size_t i = 0; i < N; ++i) if (ref[i] != fkl[i]) ++bad;
+    printf("[%s] %-14s       mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", "Not_8u_C1R", bad, N);
+    cudaFree(ds); cudaFree(dd);
+    return bad;
+}
+
+} // namespace
+
+int launch() {
+    int bad = 0;
+    for (Npp8u K : {Npp8u(0x0F), Npp8u(0xAA), Npp8u(0xFF)}) {
+        bad += bwConstC1<Npp8u>("AndC_8u_C1R", K, nppiAndC_8u_C1R_Ctx, fastNPP::AndC_8u_C1R_Ctx(K));
+        bad += bwConstC1<Npp8u>("OrC_8u_C1R",  K, nppiOrC_8u_C1R_Ctx,  fastNPP::OrC_8u_C1R_Ctx(K));
+        bad += bwConstC1<Npp8u>("XorC_8u_C1R", K, nppiXorC_8u_C1R_Ctx, fastNPP::XorC_8u_C1R_Ctx(K));
+    }
+    bad += notC1();
+
+    bad += mathC1("Abs_32f_C1R",  nppiAbs_32f_C1R_Ctx,  fastNPP::Abs_32f_C1R_Ctx(),  -100.f, 100.f,  1e-6f);
+    bad += mathC1("Sqr_32f_C1R",  nppiSqr_32f_C1R_Ctx,  fastNPP::Sqr_32f_C1R_Ctx(),  -50.f,  50.f,   1e-2f);
+    bad += mathC1("Sqrt_32f_C1R", nppiSqrt_32f_C1R_Ctx, fastNPP::Sqrt_32f_C1R_Ctx(),  0.f,   1000.f, 1e-3f);
+    bad += mathC1("Ln_32f_C1R",   nppiLn_32f_C1R_Ctx,   fastNPP::Ln_32f_C1R_Ctx(),    0.1f,  1000.f, 1e-4f);
+    bad += mathC1("Exp_32f_C1R",  nppiExp_32f_C1R_Ctx,  fastNPP::Exp_32f_C1R_Ctx(),  -10.f,  10.f,   1e-2f);
+
+    printf("%s\n", bad == 0 ? "ALL PASS" : "FAILURES DETECTED");
+    return bad == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds the NPP bitwise and element-wise math entry points to FastNPP, mapped onto FKL functors:

- **Bitwise**: `AndC`, `OrC`, `XorC` (with constant) and `Not`, for integer types in C1/C3/C4.
- **Math (32f)**: `Abs`, `Sqr`, `Sqrt`, `Ln`, `Exp` in C1/C3.

Each entry point uses the exact NPP name and composes/fuses with neighbouring operations in an `executeOperations` chain.

## Dependency

This builds on new FKL functors added in Libraries-Openly-Fused/FusedKernelLibrary#269 (`bitwise.h`: BwAnd/BwOr/BwXor/BwNot/ShiftLeft/ShiftRight; `math.h`: Abs/Sqr/Sqrt/Ln/Exp). Merge that PR and update the `fkl` submodule first; this PR's code targets those headers.

## Tests

`tests/arithmetic/fastNPP_bitwise_math_test.cu` cross-checks each operation against the corresponding NPP `_Ctx` call (shared aligned pitch so both paths use identical memory):

```
[PASS] AndC/OrC/XorC 8u  (K = 0x0F, 0xAA, 0xFF)   0 mismatches
[PASS] Not_8u_C1R                                  0 mismatches
[PASS] Abs/Sqr/Sqrt/Ln/Exp 32f   max|d| = 0.00e+00, 0 mismatches
ALL PASS
```

Bitwise results are bit-exact; the math operations match NPP exactly (max abs diff 0.00e+00) using the CUDA float intrinsics. Integrates with CTest and returns non-zero on any mismatch.

## Environment

CUDA 13.3 / GCC 11.5, `sm_120`.
