### PR TITLE
Add AbsDiffC, bit shifts and two-image bitwise operations

### DIFF
--- a/include/fast_npp.h
+++ b/include/fast_npp.h
@@ -23,9 +23,49 @@
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/bitwise.h>
+#include <fused_kernel/algorithms/basic_ops/math.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/data/ptr_utils.h>
 
 namespace fastNPP {
+
+    // ===== AbsDiff with constant: |src - C| =====
+    constexpr inline auto AbsDiffC_8u_C1R_Ctx(const uchar& nConstant) {
+        return fk::AbsDiff<uchar>::build(nConstant);
+    }
+    constexpr inline auto AbsDiffC_16u_C1R_Ctx(const ushort& nConstant) {
+        return fk::AbsDiff<ushort>::build(nConstant);
+    }
+    constexpr inline auto AbsDiffC_32f_C1R_Ctx(const float& nConstant) {
+        return fk::AbsDiff<float>::build(nConstant);
+    }
+
+    // ===== Bit shifts by a constant amount =====
+    // NPP takes the shift amount as Npp32u.
+#define FASTNPP_DEFINE_SHIFT(NPPNAME, T, FKLOP)                            \
+    constexpr inline auto NPPNAME(const Npp32u& nConstant) {               \
+        return fk::FKLOP<T, Npp32u>::build(nConstant);                     \
+    }
+    FASTNPP_DEFINE_SHIFT(LShiftC_8u_C1R_Ctx,  uchar,  ShiftLeft)
+    FASTNPP_DEFINE_SHIFT(LShiftC_16u_C1R_Ctx, ushort, ShiftLeft)
+    FASTNPP_DEFINE_SHIFT(LShiftC_32s_C1R_Ctx, int,    ShiftLeft)
+    FASTNPP_DEFINE_SHIFT(RShiftC_8u_C1R_Ctx,  uchar,  ShiftRight)
+    FASTNPP_DEFINE_SHIFT(RShiftC_16u_C1R_Ctx, ushort, ShiftRight)
+    FASTNPP_DEFINE_SHIFT(RShiftC_32s_C1R_Ctx, int,    ShiftRight)
+
+    // ===== Two-image bitwise (And/Or/Xor) =====
+#define FASTNPP_DEFINE_TWO_IMAGE_BW(NPPNAME, T, FKLOP)                          \
+    inline auto NPPNAME(const fk::Ptr2D<T>& pSrc1, const fk::Ptr2D<T>& pSrc2) { \
+        return fk::DualSourceRead<fk::ND::_2D, T>::build(pSrc2, pSrc1)           \
+               .then(fk::FKLOP<T, T, T, fk::UnaryType>::build());               \
+    }
+    FASTNPP_DEFINE_TWO_IMAGE_BW(And_8u_C1R_Ctx, uchar,  BwAnd)
+    FASTNPP_DEFINE_TWO_IMAGE_BW(And_8u_C3R_Ctx, uchar3, BwAnd)
+    FASTNPP_DEFINE_TWO_IMAGE_BW(Or_8u_C1R_Ctx,  uchar,  BwOr)
+    FASTNPP_DEFINE_TWO_IMAGE_BW(Or_8u_C3R_Ctx,  uchar3, BwOr)
+    FASTNPP_DEFINE_TWO_IMAGE_BW(Xor_8u_C1R_Ctx, uchar,  BwXor)
+    FASTNPP_DEFINE_TWO_IMAGE_BW(Xor_8u_C3R_Ctx, uchar3, BwXor)
 
     template <int INTERPOLATION_MODE, int BATCH>
     constexpr inline auto ResizeBatch_8u32f_C3R_Advanced_Ctx(const int& nMaxWidth, const int& nMaxHeight, 

--- a/tests/arithmetic/fastNPP_absdiff_shift_test.cu
+++ b/tests/arithmetic/fastNPP_absdiff_shift_test.cu
@@ -1,0 +1,143 @@
+/* Copyright 2025 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Validates FastNPP AbsDiffC, shifts (LShiftC/RShiftC) and two-image bitwise
+// (And/Or/Xor) entry points against NVIDIA NPP.
+
+#ifdef WIN32
+#include <tests/main.h>
+#endif
+
+#include <fast_npp.h>
+#include <cuda_runtime.h>
+#include <vector>
+#include <cstdio>
+
+namespace {
+
+NppStreamContext makeCtx() {
+    NppStreamContext c{};
+    c.hStream = 0;
+    cudaGetDevice(&c.nCudaDeviceId);
+    cudaDeviceProp p{};
+    cudaGetDeviceProperties(&p, c.nCudaDeviceId);
+    c.nMultiProcessorCount = p.multiProcessorCount;
+    c.nMaxThreadsPerMultiProcessor = p.maxThreadsPerMultiProcessor;
+    c.nMaxThreadsPerBlock = p.maxThreadsPerBlock;
+    c.nSharedMemPerBlock = p.sharedMemPerBlock;
+    c.nCudaDevAttrComputeCapabilityMajor = p.major;
+    c.nCudaDevAttrComputeCapabilityMinor = p.minor;
+    cudaStreamGetFlags(c.hStream, &c.nStreamFlags);
+    return c;
+}
+
+int absDiffC() {
+    const int W = 256, H = 8;
+    const size_t N = (size_t)W * H;
+    std::vector<Npp8u> h(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) h[i] = (Npp8u)((i * 53) % 256);
+    const Npp8u K = 100;
+    fk::Ptr2D<uchar> s(W, H), d(W, H);
+    const int pitch = (int)s.ptr().dims.pitch, rb = W;
+    Npp8u *ds, *dd;
+    cudaMalloc(&ds, (size_t)pitch * H); cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(ds, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppiAbsDiffC_8u_C1R_Ctx(ds, pitch, dd, pitch, {W, H}, K, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s.ptr().data, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st,
+        fk::PerThreadRead<fk::ND::_2D, uchar>::build(s),
+        fastNPP::AbsDiffC_8u_C1R_Ctx(K),
+        fk::PerThreadWrite<fk::ND::_2D, uchar>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0; for (size_t i = 0; i < N; ++i) if (ref[i] != fkl[i]) ++bad;
+    printf("[%s] AbsDiffC_8u_C1R  K=%d mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", (int)K, bad, N);
+    cudaFree(ds); cudaFree(dd);
+    return bad;
+}
+
+template <typename NppFn, typename FKLChain>
+int shiftC(const char* label, Npp32u sh, NppFn nppFn, FKLChain chain) {
+    const int W = 256, H = 8;
+    const size_t N = (size_t)W * H;
+    std::vector<Npp8u> h(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) h[i] = (Npp8u)((i * 53) % 256);
+    fk::Ptr2D<uchar> s(W, H), d(W, H);
+    const int pitch = (int)s.ptr().dims.pitch, rb = W;
+    Npp8u *ds, *dd;
+    cudaMalloc(&ds, (size_t)pitch * H); cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(ds, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppFn(ds, pitch, sh, dd, pitch, {W, H}, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s.ptr().data, pitch, h.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st,
+        fk::PerThreadRead<fk::ND::_2D, uchar>::build(s), chain,
+        fk::PerThreadWrite<fk::ND::_2D, uchar>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0; for (size_t i = 0; i < N; ++i) if (ref[i] != fkl[i]) ++bad;
+    printf("[%s] %-14s sh=%u mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", label, sh, bad, N);
+    cudaFree(ds); cudaFree(dd);
+    return bad;
+}
+
+template <typename NppFn, typename FKLChainFn>
+int bwTwoImg(const char* label, NppFn nppFn, FKLChainFn chainFn) {
+    const int W = 256, H = 8;
+    const size_t N = (size_t)W * H;
+    std::vector<Npp8u> h1(N), h2(N), ref(N), fkl(N);
+    for (size_t i = 0; i < N; ++i) { h1[i] = (Npp8u)((i * 53) % 256); h2[i] = (Npp8u)((i * 97) % 256); }
+    fk::Ptr2D<uchar> s1(W, H), s2(W, H), d(W, H);
+    const int pitch = (int)s1.ptr().dims.pitch, rb = W;
+    Npp8u *d1, *d2, *dd;
+    cudaMalloc(&d1, (size_t)pitch * H); cudaMalloc(&d2, (size_t)pitch * H); cudaMalloc(&dd, (size_t)pitch * H);
+    cudaMemcpy2D(d1, pitch, h1.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(d2, pitch, h2.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    nppFn(d1, pitch, d2, pitch, dd, pitch, {W, H}, makeCtx());
+    cudaDeviceSynchronize();
+    cudaMemcpy2D(ref.data(), rb, dd, pitch, rb, H, cudaMemcpyDeviceToHost);
+    cudaMemcpy2D(s1.ptr().data, pitch, h1.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(s2.ptr().data, pitch, h2.data(), rb, rb, H, cudaMemcpyHostToDevice);
+    fk::Stream st;
+    fk::executeOperations<fk::TransformDPP<>>(st, chainFn(s1, s2),
+        fk::PerThreadWrite<fk::ND::_2D, uchar>::build(d));
+    st.sync();
+    cudaMemcpy2D(fkl.data(), rb, d.ptr().data, pitch, rb, H, cudaMemcpyDeviceToHost);
+    int bad = 0; for (size_t i = 0; i < N; ++i) if (ref[i] != fkl[i]) ++bad;
+    printf("[%s] %-14s (two images) mismatches=%d/%zu\n", bad ? "FAIL" : "PASS", label, bad, N);
+    cudaFree(d1); cudaFree(d2); cudaFree(dd);
+    return bad;
+}
+
+} // namespace
+
+int launch() {
+    int bad = 0;
+    bad += absDiffC();
+    bad += shiftC("LShiftC_8u_C1R", 1, nppiLShiftC_8u_C1R_Ctx, fastNPP::LShiftC_8u_C1R_Ctx(1));
+    bad += shiftC("RShiftC_8u_C1R", 2, nppiRShiftC_8u_C1R_Ctx, fastNPP::RShiftC_8u_C1R_Ctx(2));
+    bad += bwTwoImg("And_8u_C1R", nppiAnd_8u_C1R_Ctx,
+                    [](const fk::Ptr2D<uchar>& a, const fk::Ptr2D<uchar>& b){ return fastNPP::And_8u_C1R_Ctx(a, b); });
+    bad += bwTwoImg("Or_8u_C1R", nppiOr_8u_C1R_Ctx,
+                    [](const fk::Ptr2D<uchar>& a, const fk::Ptr2D<uchar>& b){ return fastNPP::Or_8u_C1R_Ctx(a, b); });
+    bad += bwTwoImg("Xor_8u_C1R", nppiXor_8u_C1R_Ctx,
+                    [](const fk::Ptr2D<uchar>& a, const fk::Ptr2D<uchar>& b){ return fastNPP::Xor_8u_C1R_Ctx(a, b); });
+    printf("%s\n", bad == 0 ? "ALL PASS" : "FAILURES DETECTED");
+    return bad == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Completes the arithmetic/logical operation family in FastNPP:

- **AbsDiffC** (`|src - C|`): 8u / 16u / 32f, C1.
- **Bit shifts**: `LShiftC` / `RShiftC` by a constant amount (8u / 16u / 32s, C1).
- **Two-image bitwise**: `And` / `Or` / `Xor` (8u, C1/C3), as single fused kernels.

Each entry point uses the exact NPP name and maps onto FKL functors.

## Dependency

Builds on FKL functors in Libraries-Openly-Fused/FusedKernelLibrary#269 (`AbsDiff`, `ShiftLeft`/`ShiftRight`, `BwAnd`/`BwOr`/`BwXor` Unary forms, `DualSourceRead`). Merge that PR and update the `fkl` submodule first.

## Tests

`tests/arithmetic/fastNPP_absdiff_shift_test.cu` cross-checks each against the matching NPP `_Ctx` call (shared aligned pitch):

```
[PASS] AbsDiffC_8u_C1R   0 mismatches
[PASS] LShiftC_8u_C1R    0 mismatches
[PASS] RShiftC_8u_C1R    0 mismatches
[PASS] And/Or/Xor_8u_C1R (two images)   0 mismatches
ALL PASS
```

Bit-exact vs NPP. Integrates with CTest.

## Environment

CUDA 13.3 / GCC 11.5, `sm_120`.
